### PR TITLE
Output Feature: Shutdown on Serial Connection Error

### DIFF
--- a/octoprint_enclosure/templates/enclosure_settings.jinja2
+++ b/octoprint_enclosure/templates/enclosure_settings.jinja2
@@ -254,7 +254,7 @@
     <div class="control-group">
       <div class="controls">
         <label class="checkbox">
-          <input type="checkbox" data-bind="checked: shutdown_on_error"> {{ _('Auto Shutdown on Error') }}
+          <input type="checkbox" data-bind="checked: shutdown_on_error"> {{ _('Auto Shutdown on Serial Connection Error') }}
         </label>
         <span class="help-inline">Choose if output should turn off automatomatically when an error or disconnect was detected.</span>
       </div>

--- a/octoprint_enclosure/templates/enclosure_settings.jinja2
+++ b/octoprint_enclosure/templates/enclosure_settings.jinja2
@@ -250,6 +250,16 @@
       </div>
     </div>
     <!-- /ko -->
+    <!-- ko ifnot: ($data.output_type() == "gcode_output" || $data.output_type() == "temperature_alarm" || $data.output_type() == "shell_output") -->
+    <div class="control-group">
+      <div class="controls">
+        <label class="checkbox">
+          <input type="checkbox" data-bind="checked: shutdown_on_error"> {{ _('Auto Shutdown on Error') }}
+        </label>
+        <span class="help-inline">Choose if output should turn off automatomatically when an error or disconnect was detected.</span>
+      </div>
+    </div>
+    <!-- /ko -->
     <!-- /ko -->
 
     <!-- ko if: ($data.output_type() == "regular" || $data.output_type() == "temp_hum_control" )  -->


### PR DESCRIPTION
I added a toggle that allows to automatically turn off an output, when there was an error detected over the serial connection or a disconnect happened.

I use this to cut the power to my printer, if it for some reason disconnects during a print. I used it as an _additional_ security measure.